### PR TITLE
add support for (sexp:record) and (sexp_attr) in record output patterns

### DIFF
--- a/self/mbe.scm
+++ b/self/mbe.scm
@@ -148,6 +148,15 @@
       (hd . tl) -> (loop tl)
       )))
 
+(define (expand-fields field_list r)  ;; (list field) (list sexp) -> (list field)
+  (match field_list with
+    (list:nil) -> (list:nil)
+    (list:cons (field:t sym sxp) rest) -> 
+        (list:cons 
+            (field:t sym (expand-pattern sxp r)) 
+            (expand-fields rest r))))
+
+
 (define (expand-pattern p r) ;; sexp, (list sexp) -> sexp
   (match p with
     (sexp:list pl)    -> (sexp:list (expand-list pl r))
@@ -155,6 +164,8 @@
     (sexp:symbol sym) -> (match (mbe/assoc sym r) with
 			    (maybe:yes v) -> v
 			    (maybe:no)    -> p)
+    (sexp:record fl)  -> (sexp:record (expand-fields fl r))
+    (sexp:attr sxp sym) -> (sexp:attr (expand-pattern sxp r) sym)
     x                 -> x
     ))
 

--- a/tests/t_macro1.scm
+++ b/tests/t_macro1.scm
@@ -1,0 +1,19 @@
+
+(include "lib/basis.scm")
+
+;; test attributes in macros
+(defmacro access_field
+  (access_field a) -> a.field)
+
+(define a_rec {field="1"})
+(printn (access_field a_rec))    ;; -> "1"
+
+
+;; test record creation in macros
+(defmacro create_record
+  (create_record a) -> {field=a})
+
+(define new_rec (create_record "test"))  ;; -> {field="test"}
+
+(printn new_rec.field) ;; -> "test"
+


### PR DESCRIPTION
This allows macros of the following forms:

```scheme
(defmacro access_field
  (access_field a) -> a.field)

;; test record creation in macros
(defmacro create_record
  (create_record a) -> {field=a})
```
