### PR TITLE
py3 support for `bootstrap.py`, `build_vm.py` and `install.py`

### DIFF
--- a/util/bootstrap.py
+++ b/util/bootstrap.py
@@ -31,7 +31,7 @@ def tweak (s):
 def system (cmd):
     if windows:
         cmd = tweak (cmd)
-    print cmd
+    print (cmd)
     if 0 != os.system (cmd):
         raise CommandFailed (cmd)
 
@@ -66,30 +66,30 @@ def sys_in_dir (where, what):
     with WorkInDir (where):
         system (what)
 
-open ('self/flags.scm', 'wb').write (
+open ('self/flags.scm', 'w').write (
 """
 (define CC "%s")
 (define CFLAGS "%s")
 """ % (gcc, cflags))
 
-print 'copying the bootstrap compiler'
+print ('copying the bootstrap compiler')
 copy ('self/bootstrap.byc', 'self/compile.byc')
 
-print 'building VM'
+print ('building VM')
 # system ('make vm')
-execfile ('util/build_vm.py')
+exec(open('util/build_vm.py').read())
 
-print 'generating posix FFI...'
+print ('generating posix FFI...')
 system ('IRKENLIB=. vm/irkvm ffi/gen/genffi.byc -gen ffi/posix.ffi')
 
-print 'compiling stage0 binary (with vm)...'
+print ('compiling stage0 binary (with vm)...')
 system ('IRKENLIB=. vm/irkvm self/compile.byc self/compile.scm -q')
 
-print 'compiling stage1 binary (with stage0):'
+print ('compiling stage1 binary (with stage0):')
 system ('IRKENLIB=. self/compile self/compile.scm -q')
 move ('self/compile.c', 'self/compile.1.c')
 
-print 'compiling stage2 binary (with stage1):'
+print ('compiling stage2 binary (with stage1):')
 system ('IRKENLIB=. self/compile self/compile.scm -q')
 move ('self/compile.c', 'self/compile.2.c')
 
@@ -111,10 +111,10 @@ def diff (p0, p1):
 # file comparison on windows?  duh, should just do it in python.
 samesame = diff ('self/compile.1.c', 'self/compile.2.c')
 if samesame:
-    print 'stage1 and stage2 identical, party on wayne!'
-    print 'consider running "python util/install.py" now'
+    print ('stage1 and stage2 identical, party on wayne!')
+    print ('consider running "python util/install.py" now')
 else:
-    print 'stage1 and stage2 output differs'
+    print ('stage1 and stage2 output differs')
 
 unlink ('self/compile.1.c')
 move ('self/compile.2.c', 'self/compile.c')

--- a/util/build_vm.py
+++ b/util/build_vm.py
@@ -24,5 +24,5 @@ elif sysname == 'Linux':
     cflags += ' -D_GNU_SOURCE -ldl'
 
 cmd = '%s %s vm/irkvm.c -o vm/irkvm' % (cc, cflags)
-print cmd
+print (cmd)
 os.system (cmd)

--- a/util/install.py
+++ b/util/install.py
@@ -26,7 +26,7 @@ def getenv_or (name, default):
         return default
 
 def system (cmd):
-    print cmd
+    print (cmd)
     if os.system (cmd) != 0:
         sys.stderr.write ('system cmd failed: %r\n' % (cmd,))
         raise SystemError
@@ -52,7 +52,7 @@ copy_tree ('include', IRKENTOP, ['.h', '.c', '.ll'])
 copy_tree ('ffi', IRKENTOP, ['_ffi.scm'])
 
 # we need a new binary with the new CFLAGS
-print 'building new binary with updated CFLAGS for install...'
+print ('building new binary with updated CFLAGS for install...')
 cflags = getenv_or ('CFLAGS', '-std=c99 -O3 -fomit-frame-pointer -g -I%s' % (IRKENINC,))
 flags = open ('self/flags.scm', 'rb').read()
 
@@ -64,7 +64,7 @@ open ('self/flags.scm', 'wb').write (
 system ('self/compile self/compile.scm -q')
 
 # rebuild bytecode
-print 'building new bytecode image...'
+print ('building new bytecode image...')
 system ('self/compile self/compile.scm -b -q')
 
 # copy binary
@@ -77,6 +77,6 @@ system ('cp -p self/compile.byc %s/' % (IRKENLIB,))
 open ('vm/irkc', 'wb').write (
     "#!/bin/sh\n%s/irkvm %s/compile.byc $@\n" % (IRKENBIN, IRKENLIB)
 )
-os.chmod ('vm/irkc', 0755)
+os.chmod ('vm/irkc', 0o755)
 system ('cp -p vm/irkc %s/' % (IRKENBIN,))
 


### PR DESCRIPTION
Straightforward, minimal py3 support changes to build/install scripts. Tested.