### PR TITLE
%rextend: added for C backend only.

### DIFF
--- a/include/header1.c
+++ b/include/header1.c
@@ -794,6 +794,7 @@ irk_get_errno (void)
   return TAG_INTEGER ((irk_int) errno);
 }
 
+#define LOOKUP_FIELD(rec,label) lookup_field ((GET_TYPECODE(*rec)-TC_USEROBJ)>>2,label)
 
 // used to lookup record elements when the index
 //  cannot be computed at compile-time.

--- a/self/backend.scm
+++ b/self/backend.scm
@@ -148,11 +148,9 @@
 		      _ -> (impossible))) sig))
 	(sig (filter (lambda (x) (not (eq? x '...))) sig)))
     (let ((candidates '()))
-      (for-each
-       (lambda (sig0)
-         (if (subset? sig sig0)
-             (push! candidates sig0)))
-       (cmap/keys the-context.records))
+      (for-list sig0 (cmap/keys the-context.records)
+        (if (subset? sig sig0)
+            (push! candidates sig0)))
       (if (= 1 (length candidates))
 	  ;; unambiguous - there's only one possible match.
 	  (maybe:yes (nth candidates 0))

--- a/self/cps.scm
+++ b/self/cps.scm
@@ -689,10 +689,23 @@
                   (add-to-set k.target k.free)
                   lenv k))
                 ))
-	  _ -> (c-record-extension fields exp lenv k))))
+	  _ -> (c-record-extension (first fields) exp lenv k))))
 
-    (define (c-record-extension fields exp lenv k)
-      (error "c-record-extension: NYI"))
+    (define (c-record-extension field exp lenv k)
+      (match field with
+        (:pair new-field new-value)
+        -> (let ((osig (get-record-sig (noderec->type exp)))
+                 (nsig (sort symbol<? (list:cons new-field osig)))
+                 (otag (get-record-tag osig))
+                 (ntag (get-record-tag nsig)))
+             (c-primargs (list exp new-value)
+                         '%record-ext
+                         (sexp (int otag) (int ntag)
+                               (sexp:list (map sexp:symbol osig))
+                               (sexp:list (map sexp:symbol nsig))
+                               (sexp:symbol new-field))
+                         (noderec->type exp)
+                         lenv k))))
 
     (define (record-label-tag label)
       (cmap/add the-context.labels label))


### PR DESCRIPTION
This was implemented _waaaaay_ back in the python compiler.
Needs to be 'ported' to the llvm & bytecode backends.
